### PR TITLE
[13.0][UPD] account_payment_term_base_date: changed addon dependency from account to OCA's account_payment_term_extension

### DIFF
--- a/account_payment_term_base_date/README.rst
+++ b/account_payment_term_base_date/README.rst
@@ -25,10 +25,23 @@ The new base date is initially set with Invoice Date, or today, as Odoo does.
 Once set, this date (that is always editable) will be used in due dates 
 calculations, instead of Invoice Date.
 
+This addon depends on OCA's `account_payment_term_extension <https://github.com/OCA/account-payment/tree/13.0/account_payment_term_extension>`_.
+
+Changelog:
+
+* 13.0.1.0.0 - Initial version, only depending of standard payment terms.
+* 13.0.2.0.0 - Changed to ``account_payment_term_extension`` dependency
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Known issues / Roadmap
+======================
+
+* Split addon in two, so ``account_payment_term_extension`` becomes an
+  optional dependency.
 
 Bug Tracker
 ===========

--- a/account_payment_term_base_date/__manifest__.py
+++ b/account_payment_term_base_date/__manifest__.py
@@ -7,10 +7,10 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     'category': "Account",
     "website": "https://github.com/solvosci/slv-account",
-    "depends": ["account"],
+    "depends": ["account_payment_term_extension"],
     "data": [
         "views/account_move_views.xml",
     ],

--- a/account_payment_term_base_date/readme/DESCRIPTION.rst
+++ b/account_payment_term_base_date/readme/DESCRIPTION.rst
@@ -3,3 +3,10 @@ Enables using a base date for payment computation.
 The new base date is initially set with Invoice Date, or today, as Odoo does.
 Once set, this date (that is always editable) will be used in due dates 
 calculations, instead of Invoice Date.
+
+This addon depends on OCA's `account_payment_term_extension <https://github.com/OCA/account-payment/tree/13.0/account_payment_term_extension>`_.
+
+Changelog:
+
+* 13.0.1.0.0 - Initial version, only depending of standard payment terms.
+* 13.0.2.0.0 - Changed to ``account_payment_term_extension`` dependency

--- a/account_payment_term_base_date/readme/ROADMAP.rst
+++ b/account_payment_term_base_date/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Split addon in two, so ``account_payment_term_extension`` becomes an
+  optional dependency.

--- a/account_payment_term_base_date/static/description/index.html
+++ b/account_payment_term_base_date/static/description/index.html
@@ -372,20 +372,34 @@ ul.auto-toc {
 <p>The new base date is initially set with Invoice Date, or today, as Odoo does.
 Once set, this date (that is always editable) will be used in due dates
 calculations, instead of Invoice Date.</p>
+<p>This addon depends on OCA’s <a class="reference external" href="https://github.com/OCA/account-payment/tree/13.0/account_payment_term_extension">account_payment_term_extension</a>.</p>
+<p>Changelog:</p>
+<ul class="simple">
+<li>13.0.1.0.0 - Initial version, only depending of standard payment terms.</li>
+<li>13.0.2.0.0 - Changed to <tt class="docutils literal">account_payment_term_extension</tt> dependency</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Split addon in two, so <tt class="docutils literal">account_payment_term_extension</tt> becomes an
+optional dependency.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/solvosci/slv-account/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -393,21 +407,21 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Solvos</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>David Alonso &lt;<a class="reference external" href="mailto:david.alonso&#64;solvos.es">david.alonso&#64;solvos.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/solvosci/slv-account/tree/13.0/account_payment_term_base_date">solvosci/slv-account</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 account-invoicing
 account-invoice-reporting
+account-payment
 slv-stock-priv


### PR DESCRIPTION
This change makes `account_payment_term_extension` mandatory when installing addon