### PR TITLE
[14.0][FIX] account_move_partner_category: use invoice commercial partner

### DIFF
--- a/account_move_partner_category/__manifest__.py
+++ b/account_move_partner_category/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Accounting & Finance",
     "website": "https://github.com/solvosci/slv-account",
     "depends": ["account"],

--- a/account_move_partner_category/migrations/14.0.1.0.1/post-migration.py
+++ b/account_move_partner_category/migrations/14.0.1.0.1/post-migration.py
@@ -1,0 +1,19 @@
+# © 2022 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Recompute field in order to propagate new values
+    Only those invoices with a different commercial partner to invoice partner
+    will be recomputed
+    """
+    # TODO Postgres code if there's too invoices
+    # TODO equivalent to search([]).filtered(lambda x: x.partner_id != x.commercial_partner_id)
+    #      but faster
+    env["account.move"].search([
+        ("partner_id.is_company", "=", False),
+        ("partner_id.parent_id", "!=", False),
+    ])._compute_partner_categories()

--- a/account_move_partner_category/models/account_move.py
+++ b/account_move_partner_category/models/account_move.py
@@ -7,7 +7,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     partner_category_ids = fields.Many2many(
-        related="partner_id.category_id",
+        related="commercial_partner_id.category_id",
     )
     partner_category_count = fields.Integer(
         compute="_compute_partner_categories",


### PR DESCRIPTION
With this fix categories for invoices are obtained from invoice commercial partner, instead of direct partner, which is more accurate