### PR TITLE
[13.0][FIX] purchase_account_invoice_report_grouped_by_picking: refund invoiices created from reverse move option

### DIFF
--- a/purchase_account_invoice_report_grouped_by_picking/__manifest__.py
+++ b/purchase_account_invoice_report_grouped_by_picking/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Account Invoice Grouped by Picking - extended to Purchase",
     "summary": "Print invoice lines grouped by picking, including purchase invoices",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.0.2",
     "category": "Accounting & Finance",
     "website": "https://github.com/solvosci/slv-account",
     "author": "Solvos",


### PR DESCRIPTION
According to original sales code, this clause should be added (properly addapted to vendor bills coverage):

![imagen](https://user-images.githubusercontent.com/12749832/226669925-aaf6dd85-6d40-4fa1-ba74-92f4a12f891b.png)

Before this fix, sales refund invoices were wrongly splitted with a "Without reference" section and picking sections had wrong sign. This PR fix it.

cc @ChristianSantamaria 