### PR TITLE
[17.0][FIX] account_invoice_report_refund_total: error on purchase/sale order reports

### DIFF
--- a/account_invoice_report_refund_total/__manifest__.py
+++ b/account_invoice_report_refund_total/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     'category': "Accounting & Finance",
     "website": "https://github.com/solvosci/slv-account",
     "depends": ["account"],

--- a/account_invoice_report_refund_total/reports/account_invoice_template.xml
+++ b/account_invoice_report_refund_total/reports/account_invoice_template.xml
@@ -1,23 +1,34 @@
 <odoo>
     <template id="document_tax_totals_template_total_refund" inherit_id="account.document_tax_totals_template">
+        <xpath expr="//tr[contains(@class, 'o_total')]//strong" position="before">
+                <t t-set="total_doc" t-value="doc or o" />
+        </xpath>
         <xpath expr="//tr[contains(@class, 'o_total')]//strong" position="attributes">
-                <attribute name="t-if">not o.reversed_entry_id</attribute>
+            <attribute name="t-if">
+                total_doc._name != 'account.move' or (total_doc._name == 'account.move' and not total_doc.reversed_entry_id)
+            </attribute>
         </xpath>
 
+
         <xpath expr="//tr[contains(@class, 'o_total')]/td" position="inside">
-            <t t-if="o.reversed_entry_id">
+            <t t-if="total_doc._name == 'account.move' and total_doc.reversed_entry_id">
                 <strong style="color: red">Total Refund</strong>
             </t>
         </xpath>
     </template>
 
     <template id="document_tax_totals_company_currency_template_refund" inherit_id="account.document_tax_totals_company_currency_template">
+        <xpath expr="//tr[contains(@class, 'o_total')]//strong" position="before">
+                <t t-set="total_doc" t-value="doc or o" />
+        </xpath>
         <xpath expr="//tr[contains(@class, 'o_total')]//strong" position="attributes">
-                <attribute name="t-if">not o.reversed_entry_id</attribute>
+                <attribute name="t-if">
+                    total_doc._name != 'account.move' or (total_doc._name == 'account.move' and not total_doc.reversed_entry_id)
+                </attribute>
         </xpath>
 
         <xpath expr="//tr[contains(@class, 'o_total')]/td" position="inside">
-            <t t-if="o.reversed_entry_id">
+            <t t-if="total_doc._name == 'account.move' and total_doc.reversed_entry_id">
                 <strong style="color: red">Total Refund</strong>
             </t>
         </xpath>


### PR DESCRIPTION
The fragment that is modified, sub-templates of the account module for managing totals, is not only used in the invoice form, also in the purchase order and quotation/sales order forms. The result is that, when printing the reports, it tries to access ‘reversed_entry_id’, which is a field that does not exist for purchase or sales orders.

ticket HT00853
@dalonsod 